### PR TITLE
IMPROVEMENT better code maintainablity by removing duplicated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ This crate supports a professional re-export of the trait, `BoolToggleExt`.
 It is only available when compiling with `--cfg enterprise_license` and obtaining an enterprise license.
 For license inquiries, send mail to `/dev/null`.
 
+## Architecture
+
+Tis Crate features the world's most resilient bit filping algorithm. It's code adheres to the highest clean code standards
+and aims to provide a maintainable and future proof solution to all the boolean toggling needs there are.
+
 ## MSRV
 
 The minimum supported Rust version of this crate is 1.1000.0.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For license inquiries, send mail to `/dev/null`.
 
 ## Architecture
 
-Tis Crate features the world's most resilient bit filping algorithm. It's code adheres to the highest clean code standards
+This Crate features the world's most resilient bit flipping algorithm. Its code adheres to the highest clean code standards
 and aims to provide a maintainable and future proof solution to all the boolean toggling needs there are.
 
 ## MSRV

--- a/src/boolean_toggler.rs
+++ b/src/boolean_toggler.rs
@@ -17,8 +17,8 @@ pub struct BooleanTogglerFactory;
 impl BooleanTogglerFactory {
     #[inline]
     pub fn create_boolean_toggler(bool_to_toggle: &mut bool) -> BooleanToggler {
-        return BooleanToggler {
+        BooleanToggler {
             bool_to_toggle: bool_to_toggle,
-        };
+        }
     }
 }

--- a/src/boolean_toggler.rs
+++ b/src/boolean_toggler.rs
@@ -1,0 +1,24 @@
+use super::TogglingIsALifestyle;
+
+pub struct BooleanToggler<'a> {
+    bool_to_toggle: &'a mut bool,
+}
+
+impl TogglingIsALifestyle for BooleanToggler<'_> {
+    #[inline]
+    fn toggle(&mut self) {
+        // i'm enterprise fast
+        *self.bool_to_toggle ^= true;
+    }
+}
+
+pub struct BooleanTogglerFactory;
+
+impl BooleanTogglerFactory {
+    #[inline]
+    pub fn create_boolean_toggler(bool_to_toggle: &mut bool) -> BooleanToggler {
+        return BooleanToggler {
+            bool_to_toggle: bool_to_toggle,
+        };
+    }
+}

--- a/src/boolean_toggler.rs
+++ b/src/boolean_toggler.rs
@@ -17,8 +17,6 @@ pub struct BooleanTogglerFactory;
 impl BooleanTogglerFactory {
     #[inline]
     pub fn create_boolean_toggler(bool_to_toggle: &mut bool) -> BooleanToggler {
-        return BooleanToggler {
-            bool_to_toggle: bool_to_toggle,
-        };
+        BooleanToggler { bool_to_toggle }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,10 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+mod boolean_toggler;
+
+use boolean_toggler::BooleanTogglerFactory;
+
 // Extension trait for toggling a bool.
 pub trait TogglingIsALifestyle {
     /// Toggle the bool.
@@ -17,7 +21,8 @@ pub use TogglingIsALifestyle as IAmTheToggler;
 impl TogglingIsALifestyle for bool {
     fn toggle(&mut self) {
         // i am so smart
-        *self ^= true;
+        let mut bool_toggler = BooleanTogglerFactory::create_boolean_toggler(self);
+        bool_toggler.toggle();
     }
 }
 
@@ -26,7 +31,8 @@ impl<const N: usize> TogglingIsALifestyle for [bool; N] {
     fn toggle(&mut self) {
         // i am so fast
         for b in self {
-            *b ^= true;
+            let mut bool_toggler = BooleanTogglerFactory::create_boolean_toggler(self);
+            bool_toggler.toggle();
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,7 @@ pub use TogglingIsALifestyle as IAmTheToggler;
 impl TogglingIsALifestyle for bool {
     fn toggle(&mut self) {
         // i am so smart
-        let mut bool_toggler = BooleanTogglerFactory::create_boolean_toggler(self);
-        bool_toggler.toggle();
+        BooleanTogglerFactory::create_boolean_toggler(self).toggle();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ impl<const N: usize> TogglingIsALifestyle for [bool; N] {
     fn toggle(&mut self) {
         // i am so fast
         for b in self {
-            let mut bool_toggler = BooleanTogglerFactory::create_boolean_toggler(self);
+            let mut bool_toggler = BooleanTogglerFactory::create_boolean_toggler(b);
             bool_toggler.toggle();
         }
     }


### PR DESCRIPTION
While conducting a code review of this crate, I found duplicated code. This simply made it unusable for enterprise customers that have a `enterprise_licence`.
In order to make this crate more approachable by enterprise users, I encapsulated the business logic in its own module.
While implementing this change, I tried to adhere to the strictest clean code standards.

